### PR TITLE
consume latest st2apidocgen

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
             statuscode=$(curl --silent --write-out "%{http_code}" -o openapi.yaml https://raw.githubusercontent.com/StackStorm/st2/${ST2_BRANCH}/st2common/st2common/openapi.yaml)
             if test $statuscode -ne 200; then
               echo 'openapi.yaml is not available in https://raw.githubusercontent.com/StackStorm/st2/${ST2_BRANCH}/st2common/st2common/openapi.yaml, get the openapi.yaml from master branch'
-              curl -Ss -q -o openapi.yaml https://raw.githubusercontent.com/StackStorm/st2/${ST2_BRANCH}/st2common/st2common/openapi.yaml
+              curl -Ss -q -o openapi.yaml https://raw.githubusercontent.com/StackStorm/st2/master/st2common/st2common/openapi.yaml
             fi
       - run:
           name: Install Dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,11 @@ jobs:
       - run:
           name: Fetch latest StackStorm OpenAPI spec
           command: |
-            curl -Ss -q -o openapi.yaml https://raw.githubusercontent.com/StackStorm/st2/${ST2_BRANCH}/st2common/st2common/openapi.yaml
+            statuscode=$(curl --silent --write-out "%{http_code}" -o openapi.yaml https://raw.githubusercontent.com/StackStorm/st2/${ST2_BRANCH}/st2common/st2common/openapi.yaml)
+            if test $statuscode -ne 200; then
+              echo 'openapi.yaml is not available in https://raw.githubusercontent.com/StackStorm/st2/${ST2_BRANCH}/st2common/st2common/openapi.yaml, get the openapi.yaml from master branch'
+              curl -Ss -q -o openapi.yaml https://raw.githubusercontent.com/StackStorm/st2/master/st2common/st2common/openapi.yaml
+            fi
       - run:
           name: Install Dependencies
           command: npm install
@@ -34,7 +38,7 @@ jobs:
           command: npm test
       - run:
           name: Install doc generator
-          command: npm install -g https://github.com/StackStorm/st2apidocgen
+          command: npm install -g https://github.com/Sheshagiri/st2apidocgen#shesh/fix-babel-issue
       - run:
           name: Generate API documentation
           command: |
@@ -57,6 +61,7 @@ jobs:
       - deploy:
           name: Deploying to S3
           command: |
+            echo 'sync to aws $REGION region.'
             find ~/st2apidocs/build | sed 's|[^/]*/|  |g'
             if [[  "${ST2_BRANCH}" =~ ^v[0-9]+\.[0-9]+$ ]]; then
               aws s3 sync build/ s3://api.stackstorm.com/ --region ${REGION} --delete

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
           command: npm test
       - run:
           name: Install doc generator
-          command: npm install -g https://github.com/Sheshagiri/st2apidocgen#shesh/fix-babel-issue
+          command: npm install -g https://github.com/StackStorm/st2apidocgen
       - run:
           name: Generate API documentation
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
             statuscode=$(curl --silent --write-out "%{http_code}" -o openapi.yaml https://raw.githubusercontent.com/StackStorm/st2/${ST2_BRANCH}/st2common/st2common/openapi.yaml)
             if test $statuscode -ne 200; then
               echo 'openapi.yaml is not available in https://raw.githubusercontent.com/StackStorm/st2/${ST2_BRANCH}/st2common/st2common/openapi.yaml, get the openapi.yaml from master branch'
-              curl -Ss -q -o openapi.yaml https://raw.githubusercontent.com/StackStorm/st2/master/st2common/st2common/openapi.yaml
+              curl -Ss -q -o openapi.yaml https://raw.githubusercontent.com/StackStorm/st2/${ST2_BRANCH}/st2common/st2common/openapi.yaml
             fi
       - run:
           name: Install Dependencies

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "st2apidocs",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Auto-generated StackStorm documentation",
   "main": "index.js",
   "scripts": {
@@ -26,13 +26,14 @@
     "eslint-plugin-react": "^7.14.2"
   },
   "dependencies": {
+    "@babel/core": "7.0.0",
     "@stackstorm/react-sticky": "5.0.5",
     "commonmark": "0.27.0",
     "commonmark-react-renderer": "4.3.4",
-    "http-server": "^0.11.1",
+    "http-server": "^0.12.3",
     "js-yaml": ">=3.13.1",
     "json-schema-ref-parser": "7.1.0",
-    "lodash": "4.17.11",
+    "lodash": "^4.17.15",
     "react": "15.4.2",
     "react-dom": "15.4.2",
     "react-router-dom": "^5.0.1",


### PR DESCRIPTION
this should fix #9 
this should be merged only after https://github.com/StackStorm/st2apidocgen/pull/9
fixes: #9 

TODO
- [x] update the st2apidocgen path once https://github.com/StackStorm/st2apidocgen/pull/9 is merged to master. otherwise, circleci builds will fail.