### PR TITLE
resolve js-yaml>=4.0.0 issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "commonmark": "0.27.0",
     "commonmark-react-renderer": "4.3.4",
     "http-server": "^0.12.3",
-    "js-yaml": ">=3.13.1",
+    "js-yaml": ">=4.0.0",
     "json-schema-ref-parser": "7.1.0",
     "lodash": "^4.17.15",
     "react": "15.4.2",

--- a/src/index.js
+++ b/src/index.js
@@ -107,7 +107,7 @@ class ApiDocs extends BaseComponent {
 Promise.resolve()
   .then(() => fetch('openapi.yaml'))
   .then(resp => resp.text())
-  .then(yamlString => yaml.safeLoad(yamlString))
+  .then(yamlString => yaml.load(yamlString))
   .then(spec => $RefParser.dereference(spec))
   .then(fullSpec => Object.keys(fullSpec.paths)
     .reduce((acc, url) => {


### PR DESCRIPTION
Apparently js-yaml 4.0.0 had a breaking change.
safeLoad() was removed. The changelog says to use load() instead as load() is the new safe variant.
https://github.com/nodeca/js-yaml/blob/master/CHANGELOG.md#400---2021-01-03

This is a follow-up to StackStorm/st2apidocsgen#11 . It should resolve a series of these errors:
```
(node:198) UnhandledPromiseRejectionWarning: Error: Function yaml.safeLoad is removed in js-yaml 4. Use yaml.load instead, which is now safe by default.
(node:198) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
```