### PR TITLE
Update nodejs image to v14 to fix CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: node:10
+      - image: node:14
     working_directory: ~/st2apidocs
     steps:
       - checkout


### PR DESCRIPTION
Closes #17

apt updates are not available in older `node:10` image failing the build in https://app.circleci.com/pipelines/github/StackStorm/st2apidocs/385/workflows/96fdfe14-b685-4291-8c7c-294b3042900d/jobs/915

```
/bin/bash: line 1: pip: command not found
```

This PR should fix it